### PR TITLE
Header inclusion tweaks, ensuring that libaudit development files are present

### DIFF
--- a/api/server/credentials_linux.go
+++ b/api/server/credentials_linux.go
@@ -2,8 +2,9 @@
 
 package server
 
+// #include <sys/types.h>
+// #include <pwd.h>
 // #include <stdlib.h>
-// #include "/usr/include/pwd.h"
 import "C"
 import (
 	"bytes"

--- a/pkg/audit/audit_linux.go
+++ b/pkg/audit/audit_linux.go
@@ -9,11 +9,11 @@
 package audit
 
 // #cgo LDFLAGS: -laudit
-// #include "libaudit.h"
-// #include <unistd.h>
+// #include <libaudit.h>
+// #include <stdio.h>
 // #include <stdlib.h>
 // #include <string.h>
-// #include <stdio.h>
+// #include <unistd.h>
 import "C"
 
 import (
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	AUDIT_VIRT_CONTROL    = 2500
-	AUDIT_VIRT_RESOURCE   = 2501
-	AUDIT_VIRT_MACHINE_ID = 2502
+	AUDIT_VIRT_CONTROL    = int(C.AUDIT_VIRT_CONTROL)
+	AUDIT_VIRT_RESOURCE   = int(C.AUDIT_VIRT_RESOURCE)
+	AUDIT_VIRT_MACHINE_ID = int(C.AUDIT_VIRT_MACHINE_ID)
 )
 
 func AuditValueNeedsEncoding(str string) bool {


### PR DESCRIPTION
Hi Alec, these are a few changes to how you're pulling in system headers.  The docs say that pwd.h requires declarations from sys/types.h, so I added it, and changed "" to <> for files that we expect to find in the system include directories rather than in the docker source tree.
