### PR TITLE
Accept cases where audit_open() returns 0

### DIFF
--- a/pkg/audit/audit_linux.go
+++ b/pkg/audit/audit_linux.go
@@ -61,7 +61,7 @@ func AuditLogUserEvent(event_type int, message string, result bool) error {
 	} else {
 		r = 0
 	}
-	if fd > 0 {
+	if fd != -1 {
 		cmsg := C.CString(message)
 		defer C.free(unsafe.Pointer(cmsg))
 		_, err := C.audit_log_user_message(fd, C.int(event_type), cmsg, nil, nil, nil, C.int(r))


### PR DESCRIPTION
It's probably a minor thing, but the man page says that audit_open() returns -1 in case of error, which means that we should probably treat any other return values as successful ones.
