### PR TITLE
Add the dev package for libaudit to the build env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y \
 	dpkg-sig \
 	gcc-mingw-w64 \
 	libapparmor-dev \
+	libaudit-dev \
 	libcap-dev \
 	libsqlite3-dev \
 	python-websocket \

--- a/contrib/builder/deb/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/debian-jessie/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/debian-stretch/Dockerfile
+++ b/contrib/builder/deb/debian-stretch/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM debian:stretch
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/debian-wheezy/Dockerfile
+++ b/contrib/builder/deb/debian-wheezy/Dockerfile
@@ -5,7 +5,7 @@
 FROM debian:wheezy
 RUN echo deb http://http.debian.net/debian wheezy-backports main > /etc/apt/sources.list.d/wheezy-backports.list
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/generate.sh
+++ b/contrib/builder/deb/generate.sh
@@ -53,6 +53,7 @@ for version in "${versions[@]}"; do
 		dh-systemd # for systemd debhelper integration
 		git # for "git commit" info in "docker -v"
 		libapparmor-dev # for "sys/apparmor.h"
+		libaudit-dev # for "libaudit.h" and libaudit.so
 		libdevmapper-dev # for "libdevmapper.h"
 		libsqlite3-dev # for "sqlite3.h"
 	)

--- a/contrib/builder/deb/ubuntu-debootstrap-precise/Dockerfile
+++ b/contrib/builder/deb/ubuntu-debootstrap-precise/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ubuntu-debootstrap:precise
 
-RUN apt-get update && apt-get install -y bash-completion  build-essential curl ca-certificates debhelper  git libapparmor-dev  libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion  build-essential curl ca-certificates debhelper  git libapparmor-dev libaudit-dev  libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/ubuntu-debootstrap-trusty/Dockerfile
+++ b/contrib/builder/deb/ubuntu-debootstrap-trusty/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ubuntu-debootstrap:trusty
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/ubuntu-debootstrap-vivid/Dockerfile
+++ b/contrib/builder/deb/ubuntu-debootstrap-vivid/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ubuntu-debootstrap:vivid
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/ubuntu-debootstrap-wily/Dockerfile
+++ b/contrib/builder/deb/ubuntu-debootstrap-wily/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ubuntu-debootstrap:wily
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/centos-7/Dockerfile
+++ b/contrib/builder/rpm/centos-7/Dockerfile
@@ -6,7 +6,7 @@ FROM centos:7
 
 RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/fedora-20/Dockerfile
+++ b/contrib/builder/rpm/fedora-20/Dockerfile
@@ -5,7 +5,7 @@
 FROM fedora:20
 
 RUN yum install -y @development-tools fedora-packager
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/fedora-21/Dockerfile
+++ b/contrib/builder/rpm/fedora-21/Dockerfile
@@ -5,7 +5,7 @@
 FROM fedora:21
 
 RUN yum install -y @development-tools fedora-packager
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/fedora-22/Dockerfile
+++ b/contrib/builder/rpm/fedora-22/Dockerfile
@@ -5,7 +5,7 @@
 FROM fedora:22
 
 RUN yum install -y @development-tools fedora-packager
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/generate.sh
+++ b/contrib/builder/rpm/generate.sh
@@ -54,6 +54,7 @@ for version in "${versions[@]}"; do
 
 	# this list is sorted alphabetically; please keep it that way
 	packages=(
+		audit-libs-devel # for "libaudit.h" and libaudit.so
 		btrfs-progs-devel # for "btrfs/ioctl.h" (and "version.h" if possible)
 		device-mapper-devel # for "libdevmapper.h"
 		glibc-static

--- a/contrib/builder/rpm/oraclelinux-6/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-6/Dockerfile
@@ -5,7 +5,7 @@
 FROM oraclelinux:6
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-7/Dockerfile
@@ -5,7 +5,7 @@
 FROM oraclelinux:7
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
+RUN yum install -y --enablerepo=ol7_optional_latest audit-libs-devel btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel sqlite-devel tar
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/distribution/Centos.json
+++ b/distribution/Centos.json
@@ -2,6 +2,7 @@
     "distribution": "FROM centos",
     "dependencies":[
       "  RUN yum -y update && yum install -y \\",
+      "  audit-libs-devel \\",
       "  binutils \\",
       "  btrfs-progs-devel \\",
       "  btrfs-progs \\",

--- a/distribution/DockerfileFedora
+++ b/distribution/DockerfileFedora
@@ -26,6 +26,7 @@
 # Cut for distribution specific
 FROM fedora
   RUN dnf -y update && dnf install -y \
+  audit-libs-devel \
   binutils \
   btrfs-progs-devel \
   btrfs-progs \

--- a/distribution/Fedora.json
+++ b/distribution/Fedora.json
@@ -2,6 +2,7 @@
     "distribution": "FROM fedora",
     "dependencies":[
       "  RUN dnf -y update && dnf install -y \\",
+      "  audit-libs-devel \\",
       "  binutils \\",
       "  btrfs-progs-devel \\",
       "  btrfs-progs \\",

--- a/distribution/RHEL.json
+++ b/distribution/RHEL.json
@@ -2,6 +2,7 @@
     "distribution": "FROM rhel",
     "dependencies":[
       "  RUN yum -y update && yum install -y \\",
+      "  audit-libs-devel \\",
       "  binutils \\",
       "  btrfs-progs-devel \\",
       "  btrfs-progs \\",


### PR DESCRIPTION
We're not using the generated Dockerfiles, but these look like the changes we'd need in order to guarantee that libaudit and its header file are available when we're building things the official way.
